### PR TITLE
Adding computation and plotting of trial by trial metrics

### DIFF
--- a/src/aind_dynamic_foraging_basic_analysis/metrics/trial_metrics.py
+++ b/src/aind_dynamic_foraging_basic_analysis/metrics/trial_metrics.py
@@ -19,6 +19,9 @@ def compute_all_trial_metrics(nwb):
     gocue_reward_rate,      fraction of trials with a reward
     response_reward_rate,   fraction of trials with a reward,
                             computed only on trials with a response
+    choose_right_rate,      fraction of trials where chose right,
+                            computed only on trials with a response
+
     """
     if not hasattr(nwb, "df_trials"):
         print("You need to compute df_trials: nwb_utils.create_trials_df(nwb)")
@@ -45,8 +48,14 @@ def compute_all_trial_metrics(nwb):
         df["RESPONSE_REWARD"].rolling(WIN_DUR, min_periods=MIN_EVENTS, center=True).mean()
     )
 
+    # Rolling fraction of choosing right
+    df["WENT_RIGHT"] = [x if x in [0, 1] else np.nan for x in df["animal_response"]]
+    df["choose_right_rate"] = (
+        df["WENT_RIGHT"].rolling(WIN_DUR, min_periods=MIN_EVENTS, center=True).mean()
+    )
+
     # Clean up temp columns
-    drop_cols = ["RESPONDED", "RESPONSE_REWARD"]
+    drop_cols = ["RESPONDED", "RESPONSE_REWARD", "WENT_RIGHT"]
     df = df.drop(columns=drop_cols)
 
     return df

--- a/src/aind_dynamic_foraging_basic_analysis/metrics/trial_metrics.py
+++ b/src/aind_dynamic_foraging_basic_analysis/metrics/trial_metrics.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pandas as pd
 
 # TODO, we might want to make these parameters metric specific
 WIN_DUR = 15

--- a/src/aind_dynamic_foraging_basic_analysis/metrics/trial_metrics.py
+++ b/src/aind_dynamic_foraging_basic_analysis/metrics/trial_metrics.py
@@ -1,0 +1,43 @@
+import numpy as np
+import pandas as pd
+
+WIN_DUR = 10
+
+
+def compute_all_trial_metrics(nwb):
+    """
+    Computes all trial by trial metrics
+
+    response_rate,          fraction of trials with a response
+    gocue_reward_rate,      fraction of trials with a reward
+    response_reward_rate,   fraction of trials with a reward,
+                            computed only on trials with a response
+    """
+    if not hasattr(nwb, "df_trials"):
+        print("You need to compute df_trials: nwb_utils.create_trials_df(nwb)")
+        return
+
+    df = nwb.df_trials.copy()
+
+    df["RESPONDED"] = [x in [0, 1] for x in df["animal_response"].values]
+    # Rolling fraction of goCues with a response
+    df["response_rate"] = df["RESPONDED"].rolling(WIN_DUR, min_periods=1, center=True).mean()
+
+    # Rolling fraction of goCues with a response
+    df["gocue_reward_rate"] = (
+        df["earned_reward"].rolling(WIN_DUR, min_periods=1, center=True).mean()
+    )
+
+    # Rolling fraction of responses with a response
+    df["RESPONSE_REWARD"] = [
+        x[0] if x[1] else np.nan for x in zip(df["earned_reward"], df["RESPONDED"])
+    ]
+    df["response_reward_rate"] = (
+        df["RESPONSE_REWARD"].rolling(WIN_DUR, min_periods=1, center=True).mean()
+    )
+
+    # Clean up temp columns
+    drop_cols = ["RESPONDED", "RESPONSE_REWARD"]
+    df = df.drop(columns=drop_cols)
+
+    return df

--- a/src/aind_dynamic_foraging_basic_analysis/metrics/trial_metrics.py
+++ b/src/aind_dynamic_foraging_basic_analysis/metrics/trial_metrics.py
@@ -1,7 +1,9 @@
 import numpy as np
 import pandas as pd
 
-WIN_DUR = 10
+# TODO, we might want to make these parameters metric specific
+WIN_DUR = 15
+MIN_EVENTS = 2
 
 
 def compute_all_trial_metrics(nwb):
@@ -21,11 +23,13 @@ def compute_all_trial_metrics(nwb):
 
     df["RESPONDED"] = [x in [0, 1] for x in df["animal_response"].values]
     # Rolling fraction of goCues with a response
-    df["response_rate"] = df["RESPONDED"].rolling(WIN_DUR, min_periods=1, center=True).mean()
+    df["response_rate"] = (
+        df["RESPONDED"].rolling(WIN_DUR, min_periods=MIN_EVENTS, center=True).mean()
+    )
 
     # Rolling fraction of goCues with a response
     df["gocue_reward_rate"] = (
-        df["earned_reward"].rolling(WIN_DUR, min_periods=1, center=True).mean()
+        df["earned_reward"].rolling(WIN_DUR, min_periods=MIN_EVENTS, center=True).mean()
     )
 
     # Rolling fraction of responses with a response
@@ -33,7 +37,7 @@ def compute_all_trial_metrics(nwb):
         x[0] if x[1] else np.nan for x in zip(df["earned_reward"], df["RESPONDED"])
     ]
     df["response_reward_rate"] = (
-        df["RESPONSE_REWARD"].rolling(WIN_DUR, min_periods=1, center=True).mean()
+        df["RESPONSE_REWARD"].rolling(WIN_DUR, min_periods=MIN_EVENTS, center=True).mean()
     )
 
     # Clean up temp columns

--- a/src/aind_dynamic_foraging_basic_analysis/metrics/trial_metrics.py
+++ b/src/aind_dynamic_foraging_basic_analysis/metrics/trial_metrics.py
@@ -1,3 +1,9 @@
+"""
+    Tools for computing trial by trial metrics
+    df_trials = compute_all_trial_metrics(nwb)
+
+"""
+
 import numpy as np
 
 # TODO, we might want to make these parameters metric specific

--- a/src/aind_dynamic_foraging_basic_analysis/plot/plot_session_scroller.py
+++ b/src/aind_dynamic_foraging_basic_analysis/plot/plot_session_scroller.py
@@ -56,10 +56,16 @@ def plot_session_scroller(  # noqa: C901 pragma: no cover
         df_licks = nwb.df_licks
     else:
         df_licks = None
+    if not hasattr(nwb, "df_trials"):
+        print("computing df_trials")
+        nwb.df_trials = nu.create_df_trials(nwb)
+        df_trials = nwb.df_trials
+    else:
+        df_trials = nwb.df_trials
 
     if ax is None:
         if fip_df is None:
-            fig, ax = plt.subplots(figsize=(15, 3))
+            fig, ax = plt.subplots(figsize=(15, 4))
         else:
             fig, ax = plt.subplots(figsize=(15, 8))
 
@@ -78,30 +84,32 @@ def plot_session_scroller(  # noqa: C901 pragma: no cover
         "right_reward_top": 0.75,
         "go_cue_bottom": 0,
         "go_cue_top": 1,
-        "G_1_dff-bright_bottom": 1,
-        "G_1_dff-bright_top": 2,
-        "G_2_dff-bright_bottom": 2,
-        "G_2_dff-bright_top": 3,
-        "R_1_dff-bright_bottom": 3,
-        "R_1_dff-bright_top": 4,
-        "R_2_dff-bright_bottom": 4,
-        "R_2_dff-bright_top": 5,
-        "G_1_dff-poly_bottom": 1,
-        "G_1_dff-poly_top": 2,
-        "G_2_dff-poly_bottom": 2,
-        "G_2_dff-poly_top": 3,
-        "R_1_dff-poly_bottom": 3,
-        "R_1_dff-poly_top": 4,
-        "R_2_dff-poly_bottom": 4,
-        "R_2_dff-poly_top": 5,
-        "G_1_dff-exp_bottom": 1,
-        "G_1_dff-exp_top": 2,
-        "G_2_dff-exp_bottom": 2,
-        "G_2_dff-exp_top": 3,
-        "R_1_dff-exp_bottom": 3,
-        "R_1_dff-exp_top": 4,
-        "R_2_dff-exp_bottom": 4,
-        "R_2_dff-exp_top": 5,
+        "metrics_bottom": 1,
+        "metrics_top":2,
+        "G_1_dff-bright_bottom": 2,
+        "G_1_dff-bright_top": 3,
+        "G_2_dff-bright_bottom": 3,
+        "G_2_dff-bright_top": 4,
+        "R_1_dff-bright_bottom": 4,
+        "R_1_dff-bright_top": 5,
+        "R_2_dff-bright_bottom": 5,
+        "R_2_dff-bright_top": 6,
+        "G_1_dff-poly_bottom": 2,
+        "G_1_dff-poly_top": 3,
+        "G_2_dff-poly_bottom": 3,
+        "G_2_dff-poly_top": 4,
+        "R_1_dff-poly_bottom": 4,
+        "R_1_dff-poly_top": 5,
+        "R_2_dff-poly_bottom": 5,
+        "R_2_dff-poly_top": 6,
+        "G_1_dff-exp_bottom": 2,
+        "G_1_dff-exp_top": 3,
+        "G_2_dff-exp_bottom": 3,
+        "G_2_dff-exp_top": 4,
+        "R_1_dff-exp_bottom": 4,
+        "R_1_dff-exp_top": 5,
+        "R_2_dff-exp_bottom": 5,
+        "R_2_dff-exp_top": 6,
     }
     yticks = [
         (params["left_lick_top"] - params["left_lick_bottom"]) / 2 + params["left_lick_bottom"],
@@ -160,10 +168,11 @@ def plot_session_scroller(  # noqa: C901 pragma: no cover
                 ycolors.append("darkgray")
                 ycolors.append("darkgray")
                 C["data"] = C["data"] - d_min
-                C["data"] = C["data"].values / (d_max - d_min)
+                C["data"] = C["data"].values / (d_max - d_min) 
                 C["data"] += params[channel + "_bottom"]
                 ax.plot(C.timestamps.values, C.data.values, color)
                 ax.axhline(params[channel + "_bottom"], color="k", linewidth=0.5, alpha=0.25)
+
 
     if df_licks is None:
         left_licks = df_events.query('event == "left_lick_time"')
@@ -295,6 +304,22 @@ def plot_session_scroller(  # noqa: C901 pragma: no cover
         label="go cue",
     )
 
+    # plot metrics
+    ax.axhline(params["metrics_bottom"], color="k", linewidth=0.5, alpha=.25)
+    pR = params['metrics_bottom'] + df_trials['reward_probabilityR']
+    pL = params['metrics_bottom'] + df_trials['reward_probabilityL']
+    go_cue_times_doubled = np.repeat(go_cue_times,2)[1:]
+    pR = np.repeat(pR,2)[:-1]
+    pL = np.repeat(pL,2)[:-1]
+    #ax.plot(go_cue_times_doubled, pR, color='r')
+    #ax.plot(go_cue_times_doubled, pL, color='b')
+    
+    metrics = ['response_rate']
+    for metric in metrics:
+        if metric in df_trials:
+            values = df_trials[metric] + params['metrics_bottom']
+            ax.plot(go_cue_times, values,label=metric)
+
     # Clean up plot
     ax.legend(framealpha=1, loc="lower left", reverse=True)
     ax.set_yticks(yticks)
@@ -304,9 +329,9 @@ def plot_session_scroller(  # noqa: C901 pragma: no cover
         tick.set_color(color)
     ax.set_xlabel("time (s)", fontsize=STYLE["axis_fontsize"])
     if fip_df is None:
-        ax.set_ylim(0, 1)
+        ax.set_ylim(0, 2)
     else:
-        ax.set_ylim(0, 5)
+        ax.set_ylim(0, 6)
     ax.spines["top"].set_visible(False)
     ax.spines["right"].set_visible(False)
     if fip_df is not None:

--- a/src/aind_dynamic_foraging_basic_analysis/plot/plot_session_scroller.py
+++ b/src/aind_dynamic_foraging_basic_analysis/plot/plot_session_scroller.py
@@ -123,9 +123,22 @@ def plot_session_scroller(  # noqa: C901 pragma: no cover
         + params["left_reward_bottom"],
         (params["right_reward_top"] - params["right_reward_bottom"]) / 2
         + params["right_reward_bottom"],
+        (params["metrics_top"] - params["metrics_bottom"]) * 0.25 + params["metrics_bottom"],
+        (params["metrics_top"] - params["metrics_bottom"]) * 0.50 + params["metrics_bottom"],
+        (params["metrics_top"] - params["metrics_bottom"]) * 0.75 + params["metrics_bottom"],
+        params["metrics_top"],
     ]
-    ylabels = ["left licks", "right licks", "left reward", "right reward"]
-    ycolors = ["k", "k", "r", "r"]
+    ylabels = [
+        "left licks",
+        "right licks",
+        "left reward",
+        "right reward",
+        "0.25",
+        "0.50",
+        "0.75",
+        "metrics",
+    ]
+    ycolors = ["k", "k", "r", "r", "darkgray", "darkgray", "darkgray", "k"]
 
     if fip_df is not None:
         fip_channels = [
@@ -315,18 +328,18 @@ def plot_session_scroller(  # noqa: C901 pragma: no cover
     if "pR" in metrics:
         pR = params["metrics_bottom"] + df_trials["reward_probabilityR"]
         pR = np.repeat(pR, 2)[:-1]
-        ax.plot(go_cue_times_doubled, pR, color="r")
+        ax.plot(go_cue_times_doubled, pR, color="r", label="pR")
     if "pL" in metrics:
         pL = params["metrics_bottom"] + df_trials["reward_probabilityL"]
         pL = np.repeat(pL, 2)[:-1]
-        ax.plot(go_cue_times_doubled, pL, color="b")
+        ax.plot(go_cue_times_doubled, pL, color="b", label="pL")
 
     # plot metrics if they are available
     for metric in metrics:
         if metric in df_trials:
             values = df_trials[metric] + params["metrics_bottom"]
             ax.plot(go_cue_times, values, label=metric)
-        else:
+        elif metric not in ["pL", "pR"]:
             print('Metric "{}" not available in df_trials'.format(metric))
 
     # Clean up plot

--- a/src/aind_dynamic_foraging_basic_analysis/plot/plot_session_scroller.py
+++ b/src/aind_dynamic_foraging_basic_analysis/plot/plot_session_scroller.py
@@ -286,6 +286,12 @@ def plot_session_scroller(  # noqa: C901 pragma: no cover
             "bD",
         )
 
+        # Plot baiting
+        bait_right = df_trials.query("bait_right")["goCue_start_time_in_session"].values
+        bait_left = df_trials.query("bait_left")["goCue_start_time_in_session"].values
+        ax.plot(bait_right, [params["go_cue_top"] - 0.05] * len(bait_right), "ms", label="baited")
+        ax.plot(bait_left, [params["go_cue_bottom"] + 0.05] * len(bait_left), "ms")
+
     left_reward_deliverys = df_events.query('event == "left_reward_delivery_time"')
     left_times = left_reward_deliverys.timestamps.values
     ax.vlines(
@@ -322,7 +328,6 @@ def plot_session_scroller(  # noqa: C901 pragma: no cover
     )
 
     # plot metrics
-    # TODO, plot baiting
     ax.axhline(params["metrics_bottom"], color="k", linewidth=0.5, alpha=0.25)
     go_cue_times_doubled = np.repeat(go_cue_times, 2)[1:]
     if "pR" in metrics:

--- a/src/aind_dynamic_foraging_basic_analysis/plot/plot_session_scroller.py
+++ b/src/aind_dynamic_foraging_basic_analysis/plot/plot_session_scroller.py
@@ -15,7 +15,12 @@ from aind_dynamic_foraging_basic_analysis.plot.style import (
 
 
 def plot_session_scroller(  # noqa: C901 pragma: no cover
-    nwb, ax=None, fig=None, plot_bouts=False, processing="bright"
+    nwb,
+    ax=None,
+    fig=None,
+    plot_bouts=False,
+    processing="bright",
+    metrics=["pR", "pL", "response_rate"],
 ):
     """
     Creates an interactive plot of the session.
@@ -85,7 +90,7 @@ def plot_session_scroller(  # noqa: C901 pragma: no cover
         "go_cue_bottom": 0,
         "go_cue_top": 1,
         "metrics_bottom": 1,
-        "metrics_top":2,
+        "metrics_top": 2,
         "G_1_dff-bright_bottom": 2,
         "G_1_dff-bright_top": 3,
         "G_2_dff-bright_bottom": 3,
@@ -168,11 +173,10 @@ def plot_session_scroller(  # noqa: C901 pragma: no cover
                 ycolors.append("darkgray")
                 ycolors.append("darkgray")
                 C["data"] = C["data"] - d_min
-                C["data"] = C["data"].values / (d_max - d_min) 
+                C["data"] = C["data"].values / (d_max - d_min)
                 C["data"] += params[channel + "_bottom"]
                 ax.plot(C.timestamps.values, C.data.values, color)
                 ax.axhline(params[channel + "_bottom"], color="k", linewidth=0.5, alpha=0.25)
-
 
     if df_licks is None:
         left_licks = df_events.query('event == "left_lick_time"')
@@ -305,20 +309,25 @@ def plot_session_scroller(  # noqa: C901 pragma: no cover
     )
 
     # plot metrics
-    ax.axhline(params["metrics_bottom"], color="k", linewidth=0.5, alpha=.25)
-    pR = params['metrics_bottom'] + df_trials['reward_probabilityR']
-    pL = params['metrics_bottom'] + df_trials['reward_probabilityL']
-    go_cue_times_doubled = np.repeat(go_cue_times,2)[1:]
-    pR = np.repeat(pR,2)[:-1]
-    pL = np.repeat(pL,2)[:-1]
-    #ax.plot(go_cue_times_doubled, pR, color='r')
-    #ax.plot(go_cue_times_doubled, pL, color='b')
-    
-    metrics = ['response_rate']
+    # TODO, plot baiting
+    ax.axhline(params["metrics_bottom"], color="k", linewidth=0.5, alpha=0.25)
+    go_cue_times_doubled = np.repeat(go_cue_times, 2)[1:]
+    if "pR" in metrics:
+        pR = params["metrics_bottom"] + df_trials["reward_probabilityR"]
+        pR = np.repeat(pR, 2)[:-1]
+        ax.plot(go_cue_times_doubled, pR, color="r")
+    if "pL" in metrics:
+        pL = params["metrics_bottom"] + df_trials["reward_probabilityL"]
+        pL = np.repeat(pL, 2)[:-1]
+        ax.plot(go_cue_times_doubled, pL, color="b")
+
+    # plot metrics if they are available
     for metric in metrics:
         if metric in df_trials:
-            values = df_trials[metric] + params['metrics_bottom']
-            ax.plot(go_cue_times, values,label=metric)
+            values = df_trials[metric] + params["metrics_bottom"]
+            ax.plot(go_cue_times, values, label=metric)
+        else:
+            print('Metric "{}" not available in df_trials'.format(metric))
 
     # Clean up plot
     ax.legend(framealpha=1, loc="lower left", reverse=True)


### PR DESCRIPTION
Updated plot_session_scroller to plot metrics
- users can specify which metrics to plot by passing in a list of metrics to plot
- metrics are plotted with or without FIP data
- metrics are randomly colored, we might want to hardcode a color mapping later
- added a marker to plot whether the port is baited

Trial by trial metrics:
- [x] response_rate, fraction of trials with a response
- [x] gocue_reward_rate, fraction of trials with a reward
- [x] response_reward_rate, fraction of trials with a reward computed only on trials with a response
- [x] choose_right_rate, fraction of trials where mouse chose right computed only on trials with a response
- [x] pL, generative reward probability on the left, just added plotting
- [x] pR, generative reward probability on the right, just added plotting

Future work:
- There are many more metrics to add, but I wanted to merge this in so we have a stable ecosystem for metrics. 
- parameters for computing metrics (window duration, minimum number of events, whether to "center" the window) might want to be metric specific

DEMO
```
nwb.df_trials = compute_all_trial_metrics(nwb)
plot_session_scroller(nwb, plot_bouts=True, metrics=['response_rate','choose_right_rate'])
```
<img width="1495" alt="Screenshot 2024-11-13 at 12 03 17 PM" src="https://github.com/user-attachments/assets/91733d34-4cbd-4cc1-9f9d-cb9150c77a47">



Another example with baiting and generative reward probabilities
```
nwb.df_trials = compute_all_trial_metrics(nwb)
nwb.fip_df = create_fib_df(nwb)
plot_session_scroller(nwb, plot_bouts=True, metrics=['pR','pL'])
```
<img width="1495" alt="Screenshot 2024-11-13 at 1 38 31 PM" src="https://github.com/user-attachments/assets/c8b5f616-2a37-4ae1-a258-d4020480dece">

