### PR TITLE
Adding plotting tools for looking at mouse behavior over its lifetime

### DIFF
--- a/src/aind_dynamic_foraging_basic_analysis/multisession/multisession.py
+++ b/src/aind_dynamic_foraging_basic_analysis/multisession/multisession.py
@@ -1,30 +1,33 @@
 import os
+import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 
 from aind_dynamic_foraging_data_utils import nwb_utils as nu
 import aind_dynamic_foraging_basic_analysis.metrics.trial_metrics as tm
 
-'''
+"""
 
 # TODO
 Make specification for multisession trials df
-Make some capsule to generate them, and make data assets
+Make some capsule to generate them, and make data assets, what metadata?
 Add axis for licking/rewards
 make bias/lickspout plots dynamically loaded
-'''
+Investigate why some sessions crash on bias computation
+Add some indicator for missing session
+"""
 
 
 def make_multisession_trials_df(nwb_list, DATA_DIR, AGG_DIR):
-    '''
-        takes a list of NWBs
-        loads each NWB file
-        makes trials table
-        adds metrics
-        adds bias
-        makes aggregate trials table
-        saves aggregate trials table
-    '''
+    """
+    takes a list of NWBs
+    loads each NWB file
+    makes trials table
+    adds metrics
+    adds bias
+    makes aggregate trials table
+    saves aggregate trials table
+    """
     nwbs = []
     for n in nwb_list:
         try:
@@ -34,55 +37,115 @@ def make_multisession_trials_df(nwb_list, DATA_DIR, AGG_DIR):
             nwb.df_trials = tm.compute_bias(nwb)
             nwbs.append(nwb)
         except:
-            print('Bad {}'.format(n))
-    
+            print("Bad {}".format(n))
+
     df = pd.concat([x.df_trials for x in nwbs])
 
-    filename = os.path.join(AGG_DIR, nwb_list[0].split('/')[-1].split('_')[1]+'.csv')
+    filename = os.path.join(AGG_DIR, nwb_list[0].split("/")[-1].split("_")[1] + ".csv")
     df.to_csv(filename)
     return nwbs, df
 
 
-def plot_foraging_lifetime(lifetime_df):
-    '''
-        Takes a dataframe of the aggregate for all sessions from this animal
-        
-    '''
-    # Set up figure
-    # determine order of sessions
-    # plot each
+def plot_foraging_lifetime(lifetime_df, plot_list=["bias", "lickspout_position"]):
+    """
+    Takes a dataframe of the aggregate for all sessions from this animal
 
+    """
+
+    # Ensure dataframe is sorted by session then trial
     df = lifetime_df.copy()
-    df = df.sort_values(by=['ses_idx','trial'])
-    df['lifetime_trial'] = df.reset_index().index 
-    session_breaks = df.query('trial == 0')['lifetime_trial'].values[1:] - .5
+    df = df.sort_values(by=["ses_idx", "trial"])
+    df["lifetime_trial"] = df.reset_index().index
 
-    fig, ax = plt.subplots(2,1,figsize=(12,4),sharex=True)
-    ax[0].plot(df['lifetime_trial'],df['bias'],label='bias')   
-    ax[0].axhline(0, linestyle='--',color='k',alpha=.25)
-    ax[0].set_ylabel('bias')
-    ax[0].set_ylim(-1,1)
-    ax[0].vlines(session_breaks, -1,1,color='gray',alpha=.25,linestyle='--')
-    ax[0].set_xlim(df['lifetime_trial'].values[0], df['lifetime_trial'].values[-1])
-    ax[0].legend()
-    ax[0].spines["top"].set_visible(False)
-    ax[0].spines["right"].set_visible(False)
+    # Set up figure
+    fig, ax = plt.subplots(len(plot_list), 1, figsize=(14, 2 * len(plot_list)), sharex=True)
 
-    ax[1].plot(df['lifetime_trial'],df['lickspout_position_z']-df['lickspout_position_z'].values[0],'k',label='z')
-    ax[1].plot(df['lifetime_trial'],df['lickspout_position_y']-df['lickspout_position_y'].values[0],'r',label='y')
-    ax[1].plot(df['lifetime_trial'],df['lickspout_position_x']-df['lickspout_position_x'].values[0],'b',label='x')
-    ax[1].set_ylabel('$\Delta$ lickspout')
-    ax[1].legend()
-    ax[1].set_xlabel('Trial #')
-    ax[1].spines["top"].set_visible(False)
-    ax[1].spines["right"].set_visible(False)
-    for x in session_breaks:
-        ax[1].axvline(x,color='gray',alpha=.25,linestyle='--')
+    # Plot each element
+    for index, plot in enumerate(plot_list):
+        plot_foraging_lifetime_inner(ax[index], plot, df)
 
-    #labels = [int(x.get_text()) for x in ax[1].get_xticklabels()]
-    #labels = [x for x in labels if x < len(df)]
-    #new_labels = [df.set_index('lifetime_trial').loc[x]['trial'] for x in labels]
-    #ax[1].set_xticklabels(new_labels)
+    # Add session breaks to each axis
+    session_breaks = list(df.query("trial == 0")["lifetime_trial"].values - 0.5) + [
+        df["lifetime_trial"].values[-1]
+    ]
+    for a in ax:
+        for x in session_breaks:
+            a.axvline(x, color="gray", alpha=0.25, linestyle="--")
+
+    # Determine xtick positions and labels
+    ticks = list(df.query("trial == 0")["lifetime_trial"].values) + [
+        df["lifetime_trial"].values[-1]
+    ]
+    ticks = ticks[:-1] + np.diff(ticks) / 2
+    labels = [
+        "-".join(x.split("_")[1].split("-")[1:]) for x in df.query("trial == 0")["ses_idx"].values
+    ]
+
+    # Add ticks to the bottom plot
+    ax[-1].set_xticks(ticks, labels)
+    ax[-1].set_xlabel("Session")
+    ax[-1].set_xlim(df["lifetime_trial"].values[0], df["lifetime_trial"].values[-1])
+    plt.suptitle(df["ses_idx"].values[0].split("_")[0])
     plt.tight_layout()
 
+    def on_key_press(event):
+        """
+        Define interaction resonsivity
+        """
+        x = ax[0].get_xlim()
+        xmin = x[0]
+        xmax = x[1]
+        xStep = (xmax - xmin) / 4
+        if event.key == "<" or event.key == "," or event.key == "left":
+            xmin -= xStep
+            xmax -= xStep
+        elif event.key == ">" or event.key == "." or event.key == "right":
+            xmin += xStep
+            xmax += xStep
+        elif event.key == "up":
+            xmin -= xStep
+            xmax += xStep
+        elif event.key == "down":
+            xmin += xStep * (2 / 3)
+            xmax -= xStep * (2 / 3)
+        ax[0].set_xlim(xmin, xmax)
+        plt.draw()
 
+    kpid = fig.canvas.mpl_connect("key_press_event", on_key_press)  # noqa: F841
+
+
+def plot_foraging_lifetime_inner(ax, plot, df):
+    ax.set_ylabel(plot)
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+
+    if plot == "bias":
+        ax.plot(df["lifetime_trial"], df["bias"], label="bias")
+        ax.axhline(0, linestyle="--", color="k", alpha=0.25)
+        ax.set_ylim(-1, 1)
+    elif plot == "lickspout_position":
+        ax.plot(
+            df["lifetime_trial"],
+            df["lickspout_position_z"] - df["lickspout_position_z"].values[0],
+            "k",
+            label="z",
+        )
+        ax.plot(
+            df["lifetime_trial"],
+            df["lickspout_position_y"] - df["lickspout_position_y"].values[0],
+            "r",
+            label="y",
+        )
+        ax.plot(
+            df["lifetime_trial"],
+            df["lickspout_position_x"] - df["lickspout_position_x"].values[0],
+            "b",
+            label="x",
+        )
+        ax.set_ylabel("$\Delta$ lickspout")
+    elif plot in df:
+        ax.plot(df["lifetime_trial"], df[plot], label=plot)
+    else:
+        print("Unknown plot element: {}".format(plot))
+
+    ax.legend(loc="upper left")

--- a/src/aind_dynamic_foraging_basic_analysis/multisession/multisession.py
+++ b/src/aind_dynamic_foraging_basic_analysis/multisession/multisession.py
@@ -1,8 +1,18 @@
 import os
 import pandas as pd
+import matplotlib.pyplot as plt
 
 from aind_dynamic_foraging_data_utils import nwb_utils as nu
 import aind_dynamic_foraging_basic_analysis.metrics.trial_metrics as tm
+
+'''
+
+# TODO
+Make specification for multisession trials df
+Make some capsule to generate them, and make data assets
+Add axis for licking/rewards
+make bias/lickspout plots dynamically loaded
+'''
 
 
 def make_multisession_trials_df(nwb_list, DATA_DIR, AGG_DIR):
@@ -17,14 +27,62 @@ def make_multisession_trials_df(nwb_list, DATA_DIR, AGG_DIR):
     '''
     nwbs = []
     for n in nwb_list:
-        nwb = nu.load_nwb_from_filename(n)
-        nwb.df_trials = nu.create_df_trials(nwb)
-        nwb.df_trials = tm.compute_trial_metrics(nwb)
-        nwb.df_trials = tm.compute_bias(nwb)
-        nwbs.append(nwb)
+        try:
+            nwb = nu.load_nwb_from_filename(n)
+            nwb.df_trials = nu.create_df_trials(nwb)
+            nwb.df_trials = tm.compute_trial_metrics(nwb)
+            nwb.df_trials = tm.compute_bias(nwb)
+            nwbs.append(nwb)
+        except:
+            print('Bad {}'.format(n))
     
     df = pd.concat([x.df_trials for x in nwbs])
 
     filename = os.path.join(AGG_DIR, nwb_list[0].split('/')[-1].split('_')[1]+'.csv')
     df.to_csv(filename)
     return nwbs, df
+
+
+def plot_foraging_lifetime(lifetime_df):
+    '''
+        Takes a dataframe of the aggregate for all sessions from this animal
+        
+    '''
+    # Set up figure
+    # determine order of sessions
+    # plot each
+
+    df = lifetime_df.copy()
+    df = df.sort_values(by=['ses_idx','trial'])
+    df['lifetime_trial'] = df.reset_index().index 
+    session_breaks = df.query('trial == 0')['lifetime_trial'].values[1:] - .5
+
+    fig, ax = plt.subplots(2,1,figsize=(12,4),sharex=True)
+    ax[0].plot(df['lifetime_trial'],df['bias'],label='bias')   
+    ax[0].axhline(0, linestyle='--',color='k',alpha=.25)
+    ax[0].set_ylabel('bias')
+    ax[0].set_ylim(-1,1)
+    ax[0].vlines(session_breaks, -1,1,color='gray',alpha=.25,linestyle='--')
+    ax[0].set_xlim(df['lifetime_trial'].values[0], df['lifetime_trial'].values[-1])
+    ax[0].legend()
+    ax[0].spines["top"].set_visible(False)
+    ax[0].spines["right"].set_visible(False)
+
+    ax[1].plot(df['lifetime_trial'],df['lickspout_position_z']-df['lickspout_position_z'].values[0],'k',label='z')
+    ax[1].plot(df['lifetime_trial'],df['lickspout_position_y']-df['lickspout_position_y'].values[0],'r',label='y')
+    ax[1].plot(df['lifetime_trial'],df['lickspout_position_x']-df['lickspout_position_x'].values[0],'b',label='x')
+    ax[1].set_ylabel('$\Delta$ lickspout')
+    ax[1].legend()
+    ax[1].set_xlabel('Trial #')
+    ax[1].spines["top"].set_visible(False)
+    ax[1].spines["right"].set_visible(False)
+    for x in session_breaks:
+        ax[1].axvline(x,color='gray',alpha=.25,linestyle='--')
+
+    #labels = [int(x.get_text()) for x in ax[1].get_xticklabels()]
+    #labels = [x for x in labels if x < len(df)]
+    #new_labels = [df.set_index('lifetime_trial').loc[x]['trial'] for x in labels]
+    #ax[1].set_xticklabels(new_labels)
+    plt.tight_layout()
+
+

--- a/src/aind_dynamic_foraging_basic_analysis/multisession/multisession.py
+++ b/src/aind_dynamic_foraging_basic_analysis/multisession/multisession.py
@@ -1,0 +1,30 @@
+import os
+import pandas as pd
+
+from aind_dynamic_foraging_data_utils import nwb_utils as nu
+import aind_dynamic_foraging_basic_analysis.metrics.trial_metrics as tm
+
+
+def make_multisession_trials_df(nwb_list, DATA_DIR, AGG_DIR):
+    '''
+        takes a list of NWBs
+        loads each NWB file
+        makes trials table
+        adds metrics
+        adds bias
+        makes aggregate trials table
+        saves aggregate trials table
+    '''
+    nwbs = []
+    for n in nwb_list:
+        nwb = nu.load_nwb_from_filename(n)
+        nwb.df_trials = nu.create_df_trials(nwb)
+        nwb.df_trials = tm.compute_trial_metrics(nwb)
+        nwb.df_trials = tm.compute_bias(nwb)
+        nwbs.append(nwb)
+    
+    df = pd.concat([x.df_trials for x in nwbs])
+
+    filename = os.path.join(AGG_DIR, nwb_list[0].split('/')[-1].split('_')[1]+'.csv')
+    df.to_csv(filename)
+    return nwbs, df

--- a/src/aind_dynamic_foraging_basic_analysis/plot/plot_foraging_session.py
+++ b/src/aind_dynamic_foraging_basic_analysis/plot/plot_foraging_session.py
@@ -21,25 +21,6 @@ def moving_average(a, n=3):
     ret[n:] = ret[n:] - ret[:-n]
     return ret[(n - 1) :] / n  # noqa: E203
 
-def plot_foraging_lifetime(lifetime_df_trials):
-    '''
-        Takes a dataframe of the aggregate for all sessions from this animal
-        
-    '''
-    fig, ax = plt.subplots(2,1,figsize=(8,4))
-    
-    ax[0].plot(nwb.df_trials['bias'],'g',label='bias')
-    ax[0].axhline(0, linestyle='--',color='k',alpha=.25)
-    ax[0].set_ylabel('bias')
-    ax[0].set_ylim(-1,1)
-    ax[1].plot(nwb.df_trials['lickspout_position_z']-nwb.df_trials['lickspout_position_z'].values[0],'k',label='z')
-    ax[1].plot(nwb.df_trials['lickspout_position_y']-nwb.df_trials['lickspout_position_y'].values[0],'r',label='y')
-    ax[1].plot(nwb.df_trials['lickspout_position_x']-nwb.df_trials['lickspout_position_x'].values[0],'b',label='x')
-    ax[1].set_ylabel('$\Delta$ lickspout')
-    ax[1].legend()
-    ax[1].set_xlabel('Trial #')
-    plt.tight_layout()
-
 
 def plot_foraging_session_nwb(nwb, **kwargs):
     """

--- a/src/aind_dynamic_foraging_basic_analysis/plot/plot_foraging_session.py
+++ b/src/aind_dynamic_foraging_basic_analysis/plot/plot_foraging_session.py
@@ -16,7 +16,9 @@ from aind_dynamic_foraging_basic_analysis.plot.style import PHOTOSTIM_EPOCH_MAPP
 
 
 def moving_average(a, n=3):
-    """Compute moving average of a list or array."""
+    """
+    Compute moving average of a list or array.
+    """
     ret = np.nancumsum(a, dtype=float)
     ret[n:] = ret[n:] - ret[:-n]
     return ret[(n - 1) :] / n  # noqa: E203

--- a/src/aind_dynamic_foraging_basic_analysis/plot/plot_foraging_session.py
+++ b/src/aind_dynamic_foraging_basic_analysis/plot/plot_foraging_session.py
@@ -21,6 +21,25 @@ def moving_average(a, n=3):
     ret[n:] = ret[n:] - ret[:-n]
     return ret[(n - 1) :] / n  # noqa: E203
 
+def plot_foraging_lifetime(lifetime_df_trials):
+    '''
+        Takes a dataframe of the aggregate for all sessions from this animal
+        
+    '''
+    fig, ax = plt.subplots(2,1,figsize=(8,4))
+    
+    ax[0].plot(nwb.df_trials['bias'],'g',label='bias')
+    ax[0].axhline(0, linestyle='--',color='k',alpha=.25)
+    ax[0].set_ylabel('bias')
+    ax[0].set_ylim(-1,1)
+    ax[1].plot(nwb.df_trials['lickspout_position_z']-nwb.df_trials['lickspout_position_z'].values[0],'k',label='z')
+    ax[1].plot(nwb.df_trials['lickspout_position_y']-nwb.df_trials['lickspout_position_y'].values[0],'r',label='y')
+    ax[1].plot(nwb.df_trials['lickspout_position_x']-nwb.df_trials['lickspout_position_x'].values[0],'b',label='x')
+    ax[1].set_ylabel('$\Delta$ lickspout')
+    ax[1].legend()
+    ax[1].set_xlabel('Trial #')
+    plt.tight_layout()
+
 
 def plot_foraging_session_nwb(nwb, **kwargs):
     """


### PR DESCRIPTION
- utility for aggregating NWBs from a single mouse, and making a combined dataframe. This is a temporary solution, since we are planning out how to do "second order" analyses like this
- A plotting function that takes the aggregated dataframe of trials. This should be permanent whatever the outcome of the second order analyses planning looks like
- [ ] linting
- [ ] testing
- [ ] aggregation code was failing on some sessions. Might be an edge case I'm not covering
- [ ] plot clean up, edge cases, add more information on the plots
