### PR TITLE
adding color flexibility

### DIFF
--- a/src/aind_dynamic_foraging_basic_analysis/plot/plot_fip.py
+++ b/src/aind_dynamic_foraging_basic_analysis/plot/plot_fip.py
@@ -10,7 +10,9 @@ from aind_dynamic_foraging_data_utils import nwb_utils as nu
 from aind_dynamic_foraging_basic_analysis.plot.style import STYLE, FIP_COLORS
 
 
-def plot_fip_psth_compare_alignments(nwb, alignments, channel, tw=[-4, 4], censor=True):
+def plot_fip_psth_compare_alignments(
+    nwb, alignments, channel, tw=[-4, 4], censor=True, extra_colors={}
+):
     """
     Compare the same FIP channel aligned to multiple event types
     nwb, nwb object for the session
@@ -18,6 +20,7 @@ def plot_fip_psth_compare_alignments(nwb, alignments, channel, tw=[-4, 4], censo
         whose keys are event types and values are a list of timepoints
     channel, (str) the name of the FIP channel
     tw, time window for the PSTH
+    extra_colors (dict), a dictionary of extra colors. keys should be alignments, or colors are random
 
     EXAMPLE
     *******************
@@ -63,11 +66,13 @@ def plot_fip_psth_compare_alignments(nwb, alignments, channel, tw=[-4, 4], censo
 
     fig, ax = plt.subplots()
 
+    colors = {**FIP_COLORS, **extra_colors}
+
     for alignment in align_dict:
         etr = fip_psth_inner_compute(
             nwb, align_dict[alignment], channel, True, tw, censor, censor_times
         )
-        fip_psth_inner_plot(ax, etr, FIP_COLORS.get(alignment, ""), alignment)
+        fip_psth_inner_plot(ax, etr, colors.get(alignment, ""), alignment)
 
     plt.legend()
     ax.set_xlabel(align_label, fontsize=STYLE["axis_fontsize"])

--- a/src/aind_dynamic_foraging_basic_analysis/plot/plot_fip.py
+++ b/src/aind_dynamic_foraging_basic_analysis/plot/plot_fip.py
@@ -20,7 +20,8 @@ def plot_fip_psth_compare_alignments(
         whose keys are event types and values are a list of timepoints
     channel, (str) the name of the FIP channel
     tw, time window for the PSTH
-    extra_colors (dict), a dictionary of extra colors. keys should be alignments, or colors are random
+    extra_colors (dict), a dictionary of extra colors.
+        keys should be alignments, or colors are random
 
     EXAMPLE
     *******************


### PR DESCRIPTION
Allows you to pass in a dictionary of colors. Dictionary passed in over-rides any defaults set in style.py.FIP_COLORS

```
from aind_dynamic_foraging_basic_analysis.plot import plot_fip as pf
channel = 'G_1_dff-poly'
rewarded_go_cues = nwb.df_trials.query('earned_reward == 1')['goCue_start_time_in_session'].values
unrewarded_go_cues = nwb.df_trials.query('earned_reward == 0')['goCue_start_time_in_session'].values
extra_colors={'rewarded goCue':'green','unrewarded goCue':'purple'}
fig, ax = pf.plot_fip_psth_compare_alignments(
    nwb, 
    {'rewarded goCue':rewarded_go_cues,'unrewarded goCue':unrewarded_go_cues}, 
    channel, 
    censor=True,
    extra_colors=extra_colors
    )
```

<img width="625" alt="Screenshot 2025-01-28 at 5 33 44 PM" src="https://github.com/user-attachments/assets/ca3af11f-5d39-4886-9662-156b11ccb089" />
