### PR TITLE
making lick_analysis backward compatible with nwb reorganization

### DIFF
--- a/src/aind_dynamic_foraging_basic_analysis/licks/lick_analysis.py
+++ b/src/aind_dynamic_foraging_basic_analysis/licks/lick_analysis.py
@@ -189,7 +189,11 @@ def plot_lick_analysis(nwb):
                 zorder=1,
             )
 
-        box = nwb.scratch["metadata"][0].box.values
+        # We should check lab_meta_data once its added to NWB processing
+        if ("metadata" in nwb.scratch) and ("box" in nwb.scratch["metadata"]):
+            box = nwb.scratch["metadata"][0].box.values
+        else:
+            box = "?"
         plt.suptitle(f"{session_id} in {box}")
 
         # Response latency

--- a/src/aind_dynamic_foraging_basic_analysis/licks/lick_analysis.py
+++ b/src/aind_dynamic_foraging_basic_analysis/licks/lick_analysis.py
@@ -190,10 +190,10 @@ def plot_lick_analysis(nwb):
             )
 
         # We should check lab_meta_data once its added to NWB processing
+        box = "?"
         if ("metadata" in nwb.scratch) and ("box" in nwb.scratch["metadata"]):
             box = nwb.scratch["metadata"][0].box.values
-        else:
-            box = "?"
+
         plt.suptitle(f"{session_id} in {box}")
 
         # Response latency


### PR DESCRIPTION
- Updates lick_analysis to be robust to metadata not being in scratch
- resolves #43
- Metadata should be in `nwb.lab_meta_data`, but this issue was apparently closed prematurely: https://github.com/AllenNeuralDynamics/aind-physio-arch/issues/260