### PR TITLE
Improve plot_session_scroller

### DIFF
--- a/src/aind_dynamic_foraging_basic_analysis/plot/plot_foraging_session.py
+++ b/src/aind_dynamic_foraging_basic_analysis/plot/plot_foraging_session.py
@@ -31,7 +31,7 @@ def plot_foraging_session_nwb(nwb, **kwargs):
         print("You need to compute df_trials: nwb_utils.create_trials_df(nwb)")
         return
 
-    if "bias" not in nwb.df_trials:
+    if "side_bias" not in nwb.df_trials:
         fig, axes = plot_foraging_session(
             [np.nan if x == 2 else x for x in nwb.df_trials["animal_response"].values],
             nwb.df_trials["earned_reward"].values,
@@ -40,14 +40,14 @@ def plot_foraging_session_nwb(nwb, **kwargs):
         )
     else:
         if "plot_list" not in kwargs:
-            kwargs["plot_list"] = ["choice", "finished", "reward_prob", "bias"]
+            kwargs["plot_list"] = ["choice", "reward_prob", "bias"]
         fig, axes = plot_foraging_session(
             [np.nan if x == 2 else x for x in nwb.df_trials["animal_response"].values],
             nwb.df_trials["earned_reward"].values,
             [nwb.df_trials["reward_probabilityL"], nwb.df_trials["reward_probabilityR"]],
-            bias=nwb.df_trials["bias"].values,
-            bias_lower=nwb.df_trials["bias_ci_lower"].values,
-            bias_upper=nwb.df_trials["bias_ci_upper"].values,
+            bias=nwb.df_trials["side_bias"].values,
+            bias_lower=[x[0] for x in nwb.df_trials["side_bias_confidence_interval"].values],
+            bias_upper=[x[1] for x in nwb.df_trials["side_bias_confidence_interval"].values],
             autowater_offered=nwb.df_trials[["auto_waterL", "auto_waterR"]].any(axis=1),
             **kwargs,
         )

--- a/src/aind_dynamic_foraging_basic_analysis/plot/plot_session_scroller.py
+++ b/src/aind_dynamic_foraging_basic_analysis/plot/plot_session_scroller.py
@@ -63,7 +63,7 @@ def plot_session_scroller(  # noqa: C901 pragma: no cover
         df_events = nwb.df_events
     else:
         df_events = nwb.df_events
-    if hasattr(nwb, "fip_df") and plot_fip:
+    if hasattr(nwb, "fip_df") and ("FIP" in plot_list):
         fip_df = nwb.fip_df
     else:
         fip_df = None

--- a/src/aind_dynamic_foraging_basic_analysis/plot/plot_session_scroller.py
+++ b/src/aind_dynamic_foraging_basic_analysis/plot/plot_session_scroller.py
@@ -18,10 +18,13 @@ def plot_session_scroller(  # noqa: C901 pragma: no cover
     nwb,
     ax=None,
     fig=None,
-    plot_fip=True,
     processing="bright",
     metrics=["pR", "pL", "response_rate"],
-    plot_list=["bouts", "go cue",],
+    plot_list=[
+        "FIP",
+        "bouts",
+        "go cue",
+    ],
 ):
     """
     Creates an interactive plot of the session.
@@ -37,18 +40,18 @@ def plot_session_scroller(  # noqa: C901 pragma: no cover
 
     ax is a pyplot figure axis. If None, a new figure is created
 
-    plot_fip (bool) plot FIP data, defaults True
-
     processing (str) processing method for FIP data to plot
 
     metrics (list of strings), list of metrics to plot. Must be either 'pR','pL' or
         columns in nwb.df_trials
 
+    plot_list (list of strings), list of annotations and features to plot
+
     EXAMPLES:
     plot_foraging_session.plot_session_scroller(nwb)
     """
 
-    approved_plot_list = ["bouts", "go cue", "rewarded lick", "cue response", "baiting"]
+    approved_plot_list = ["bouts", "go cue", "rewarded lick", "cue response", "baiting", "FIP"]
     unapproved = set(plot_list) - set(approved_plot_list)
     if len(unapproved) > 0:
         print("Unknown plot_list options: {}".format(list(unapproved)))

--- a/tests/test_plot_foraging_session.py
+++ b/tests/test_plot_foraging_session.py
@@ -65,7 +65,14 @@ class TestPlotSession(unittest.TestCase):
 
         # Test with bias column
         nwb.df_trials["side_bias"] = np.array([0, 0, 0.1, 0.1, 0.05, 0.05])
-        nwb.df_trials["side_bias_confidence_interval"] = np.array([[-1, 1] * 6])
+        nwb.df_trials["side_bias_confidence_interval"] = [
+            [-1, 1],
+            [-1, 1],
+            [-1, 1],
+            [-1, 1],
+            [-1, 1],
+            [-1, 1],
+        ]
         pfs.plot_foraging_session_nwb(nwb)
 
     def test_plot_session(self):

--- a/tests/test_plot_foraging_session.py
+++ b/tests/test_plot_foraging_session.py
@@ -64,9 +64,8 @@ class TestPlotSession(unittest.TestCase):
         pfs.plot_foraging_session_nwb(nwb)
 
         # Test with bias column
-        nwb.df_trials["bias"] = np.array([0, 0, 0.1, 0.1, 0.05, 0.05])
-        nwb.df_trials["bias_ci_lower"] = np.array([0] * 6)
-        nwb.df_trials["bias_ci_upper"] = np.array([0.2] * 6)
+        nwb.df_trials["side_bias"] = np.array([0, 0, 0.1, 0.1, 0.05, 0.05])
+        nwb.df_trials["side_bias_confidence_interval"] = np.array([[-1,1]*6])
         pfs.plot_foraging_session_nwb(nwb)
 
     def test_plot_session(self):

--- a/tests/test_plot_foraging_session.py
+++ b/tests/test_plot_foraging_session.py
@@ -65,7 +65,7 @@ class TestPlotSession(unittest.TestCase):
 
         # Test with bias column
         nwb.df_trials["side_bias"] = np.array([0, 0, 0.1, 0.1, 0.05, 0.05])
-        nwb.df_trials["side_bias_confidence_interval"] = np.array([[-1,1]*6])
+        nwb.df_trials["side_bias_confidence_interval"] = np.array([[-1, 1] * 6])
         pfs.plot_foraging_session_nwb(nwb)
 
     def test_plot_session(self):


### PR DESCRIPTION
- Removes `plot_bout` input argument
- Adds `plot_list` which accepts a list of annotations to plot including 'go cue' ,'rewarded lick', 'cue response', 'baiting', 'bouts', and 'FIP'. Annotations are only plotted if they are included in the plot_list

```
import aind_dynamic_foraging_basic_analysis.plot.plot_session_scroller as pss
pss.plot_session_scroller(nwb, metrics=['pR','pL'], plot_list=[])
```
<img width="1491" alt="Screenshot 2025-03-26 at 3 13 18 PM" src="https://github.com/user-attachments/assets/ade0d12b-0064-4561-8649-bbcc09f0de26" />

```
import aind_dynamic_foraging_basic_analysis.plot.plot_foraging_session as pfs
pfs.plot_foraging_session_nwb(nwb, plot_list = ['bias'])
```

<img width="1512" alt="Screenshot 2025-03-26 at 3 12 36 PM" src="https://github.com/user-attachments/assets/93fcb5c5-7be3-470f-9cc6-a205d3b92ed5" />
