### PR TITLE
Annotating possible electrical artifacts in lick patterns

### DIFF
--- a/tests/test_lick_annotation.py
+++ b/tests/test_lick_annotation.py
@@ -161,6 +161,7 @@ class TestLickAnnotation(unittest.TestCase):
 
         # Verify that we check for the existence of df_events
         assert a.annotate_lick_bouts(nwb) is None
+        assert a.annotate_artifacts(nwb) is None
         assert a.annotate_rewards(nwb) is None
         assert a.annotate_cue_response(nwb) is None
         assert a.annotate_intertrial_choices(nwb) is None
@@ -170,6 +171,8 @@ class TestLickAnnotation(unittest.TestCase):
         # Verify that we check for the prerequisite columns from other annotations
         nwb.df_events = df
         nwb.df_licks = a.annotate_lick_bouts(nwb)
+        del nwb.df_licks
+        nwb.df_licks = a.annotate_artifacts(nwb)
         del nwb.df_licks
         nwb.df_licks = a.annotate_rewards(nwb)
         del nwb.df_licks

--- a/tests/test_lick_annotation.py
+++ b/tests/test_lick_annotation.py
@@ -160,6 +160,7 @@ class TestLickAnnotation(unittest.TestCase):
         df = df.sort_values(by="timestamps")
 
         # Verify that we check for the existence of df_events
+        assert a.annotate_licks(nwb) is None
         assert a.annotate_lick_bouts(nwb) is None
         assert a.annotate_artifacts(nwb) is None
         assert a.annotate_rewards(nwb) is None


### PR DESCRIPTION
- Adds an annotation function that makes a column `likely_artifact` in `df_licks`
- Licks are marked as an artifact if the interval since the previous lick was < 0.0001 s, and the previous lick was on the other side
- Its possible these licks are actually part of grooming bouts, but they seem to happen more frequently than other short-time-scale intervals, which suggests an electrical origin
- resolves https://github.com/AllenNeuralDynamics/aind-fip-nwb-base-capsule/issues/73