### PR TITLE
Data option fip plots

### DIFF
--- a/src/aind_dynamic_foraging_basic_analysis/plot/plot_fip.py
+++ b/src/aind_dynamic_foraging_basic_analysis/plot/plot_fip.py
@@ -83,7 +83,7 @@ def plot_fip_psth_compare_alignments(  # NOQA C901
         etr = fip_psth_inner_compute(
             nwb, align_dict[alignment], channel, True, tw, censor, censor_times, data_column
         )
-        fip_psth_inner_plot(ax, etr, colors.get(alignment, ""), alignment)
+        fip_psth_inner_plot(ax, etr, colors.get(alignment, ""), alignment, data_column)
 
     plt.legend()
     ax.set_xlabel(align_label, fontsize=STYLE["axis_fontsize"])
@@ -153,7 +153,7 @@ def plot_fip_psth_compare_channels(
     for dex, c in enumerate(channels):
         if c in nwb.df_fip["event"].values:
             etr = fip_psth_inner_compute(nwb, align_timepoints, c, True, tw, censor, data_column)
-            fip_psth_inner_plot(ax, etr, colors[dex], c)
+            fip_psth_inner_plot(ax, etr, colors[dex], c, data_column)
         else:
             print("No data for channel: {}".format(c))
 
@@ -170,19 +170,21 @@ def plot_fip_psth_compare_channels(
     return fig, ax
 
 
-def fip_psth_inner_plot(ax, etr, color, label):
+def fip_psth_inner_plot(ax, etr, color, label, data_column):
     """
     helper function that plots an event triggered response
     ax, the pyplot axis to plot on
     etr, the dataframe that contains the event triggered response
     color, the line color to plot
     label, the label for the etr
+    data_column (string), name of data_column
     """
     if color == "":
         cmap = plt.get_cmap("tab20")
         color = cmap(np.random.randint(20))
-    ax.fill_between(etr.index, etr.data - etr["sem"], etr.data + etr["sem"], color=color, alpha=0.2)
-    ax.plot(etr.index, etr.data, color=color, label=label)
+    ax.fill_between(etr.index, etr[data_column] - etr["sem"],
+                    etr[data_column] + etr["sem"], color=color, alpha=0.2)
+    ax.plot(etr.index, etr[data_column], color=color, label=label)
 
 
 def fip_psth_inner_compute(

--- a/src/aind_dynamic_foraging_basic_analysis/plot/plot_fip.py
+++ b/src/aind_dynamic_foraging_basic_analysis/plot/plot_fip.py
@@ -11,10 +11,15 @@ from aind_dynamic_foraging_basic_analysis.plot.style import STYLE, FIP_COLORS
 
 
 def plot_fip_psth_compare_alignments(  # NOQA C901
-    nwb, alignments, channel, tw=[-4, 4],
-    ax=None, fig=None,
-    censor=True, extra_colors={},
-    data_column="data"
+    nwb,
+    alignments,
+    channel,
+    tw=[-4, 4],
+    ax=None,
+    fig=None,
+    censor=True,
+    extra_colors={},
+    data_column="data",
 ):
     """
     Compare the same FIP channel aligned to multiple event types
@@ -23,6 +28,7 @@ def plot_fip_psth_compare_alignments(  # NOQA C901
         whose keys are event types and values are a list of timepoints
     channel, (str) the name of the FIP channel
     tw, time window for the PSTH
+    censor, censor important timepoints before and after aligned timepoints
     extra_colors (dict), a dictionary of extra colors.
         keys should be alignments, or colors are random
     data_column (string), name of data column in nwb.df_fip
@@ -75,8 +81,7 @@ def plot_fip_psth_compare_alignments(  # NOQA C901
 
     for alignment in align_dict:
         etr = fip_psth_inner_compute(
-            nwb, align_dict[alignment], channel, True, tw, 
-            censor, censor_times, data_column
+            nwb, align_dict[alignment], channel, True, tw, censor, censor_times, data_column
         )
         fip_psth_inner_plot(ax, etr, colors.get(alignment, ""), alignment)
 
@@ -97,7 +102,8 @@ def plot_fip_psth_compare_channels(
     nwb,
     align,
     tw=[-4, 4],
-    ax=None, fig=None,
+    ax=None,
+    fig=None,
     channels=[
         "G_1_preprocessed",
         "G_2_preprocessed",
@@ -107,12 +113,16 @@ def plot_fip_psth_compare_channels(
         "Iso_2_preprocessed",
     ],
     censor=True,
+    data_column="data",
 ):
     """
     nwb, the nwb object for the session of interest
     align should either be a string of the name of an event type in nwb.df_events,
         or a list of timepoints
     channels should be a list of channel names (strings)
+    censor, censor important timepoints before and after aligned timepoints
+    data_column (string), name of data column in nwb.df_fip
+
     EXAMPLE
     ********************
     plot_fip_psth(nwb, 'goCue_start_time')
@@ -142,8 +152,7 @@ def plot_fip_psth_compare_channels(
     colors = [FIP_COLORS.get(c, "") for c in channels]
     for dex, c in enumerate(channels):
         if c in nwb.df_fip["event"].values:
-            etr = fip_psth_inner_compute(nwb, align_timepoints, c, True, 
-                        tw, censor, data_column)
+            etr = fip_psth_inner_compute(nwb, align_timepoints, c, True, tw, censor, data_column)
             fip_psth_inner_plot(ax, etr, colors[dex], c)
         else:
             print("No data for channel: {}".format(c))
@@ -177,7 +186,14 @@ def fip_psth_inner_plot(ax, etr, color, label):
 
 
 def fip_psth_inner_compute(
-    nwb, align_timepoints, channel, average, tw=[-1, 1], censor=True, censor_times=None, data_column="data"
+    nwb,
+    align_timepoints,
+    channel,
+    average,
+    tw=[-1, 1],
+    censor=True,
+    censor_times=None,
+    data_column="data",
 ):
     """
     helper function that computes the event triggered response
@@ -186,6 +202,7 @@ def fip_psth_inner_compute(
     channel, what channel in the df_fip dataframe to use
     average(bool), whether to return the average, or all individual traces
     tw, time window before and after each event
+    censor, censor important timepoints before and after aligned timepoints
     censor_times, timepoints to censor
     data_column (string), name of data column in nwb.df_fip
 

--- a/src/aind_dynamic_foraging_basic_analysis/plot/plot_session_scroller.py
+++ b/src/aind_dynamic_foraging_basic_analysis/plot/plot_session_scroller.py
@@ -82,8 +82,8 @@ def plot_session_scroller(  # noqa: C901 pragma: no cover
         df_events = nwb.df_events
     else:
         df_events = nwb.df_events
-    if hasattr(nwb, "fip_df"):
-        fip_df = nwb.fip_df
+    if hasattr(nwb, "df_fip"):
+        fip_df = nwb.df_fip
     if hasattr(nwb, "df_licks"):
         df_licks = nwb.df_licks
     elif ("bouts" in plot_list) or ("cue response" in plot_list) or ("rewarded lick" in plot_list):


### PR DESCRIPTION
adding the option to specify the data column name when we plot fip plots. 


only updated for specific plotting that compare fip data (not session_scroller for example) 