### PR TITLE
Updating FIP PSTH tools to accept multiple NWB files

### DIFF
--- a/src/aind_dynamic_foraging_basic_analysis/plot/plot_fip.py
+++ b/src/aind_dynamic_foraging_basic_analysis/plot/plot_fip.py
@@ -129,7 +129,7 @@ def plot_fip_psth_compare_alignments(  # NOQA C901
     return fig, ax
 
 
-def plot_fip_psth_compare_channels(
+def plot_fip_psth_compare_channels(  # NOQA C901
     nwb,
     align,
     tw=[-4, 4],

--- a/src/aind_dynamic_foraging_basic_analysis/plot/plot_fip.py
+++ b/src/aind_dynamic_foraging_basic_analysis/plot/plot_fip.py
@@ -272,7 +272,12 @@ def fip_psth_multiple_inner_compute(
     censor_times=None,
     data_column="data",
 ):
-    """ """
+    """
+    Wrapper function for fip_psth_inner_compute that takes a list of NWB files
+    nwb_list, a list of nwb sessions
+    align_timepoints_list, a list of alignments for each session
+    censor_times, can be None, or a list of timepoints for each session
+    """
     # Check that len(nwb_list) = len(align_timepoints_list) = len(censor_times)
     if len(nwb_list) != len(align_timepoints_list):
         raise Exception("length of nwb list and alignments list must match")

--- a/src/aind_dynamic_foraging_basic_analysis/plot/plot_fip.py
+++ b/src/aind_dynamic_foraging_basic_analysis/plot/plot_fip.py
@@ -68,6 +68,8 @@ def plot_fip_psth_compare_alignments(  # NOQA C901
     if isinstance(alignments, dict):
         # We have a single NWB, given a dictionary of alignments, make it a list and we are done
         align_list = [alignments]
+    elif isinstance(alignments, list) and all(isinstance(item, dict) for item in alignments):
+        align_list = alignments
     elif isinstance(alignments, list):
         align_list = []
         for i, nwb_i in enumerate(nwb_list):


### PR DESCRIPTION
Updates the tools in `plot.plot_fip` to operate on either a single NWB or a list of NWB files. This is a re-write and thus replaces https://github.com/AllenNeuralDynamics/aind-dynamic-foraging-basic-analysis/pull/70. This also closes https://github.com/AllenNeuralDynamics/aind-dynamic-foraging-basic-analysis/issues/48 (but does not Z-score each session as proposed in that issue)

Examples:
This original example still works as expected:
```
from aind_dynamic_foraging_basic_analysis.plot import plot_fip as pf
channel = 'G_1_dff-poly'
rewarded_go_cues = nwb.df_trials.query('earned_reward == 1')['goCue_start_time_in_session'].values
unrewarded_go_cues = nwb.df_trials.query('earned_reward == 0')['goCue_start_time_in_session'].values
pf.plot_fip_psth_compare_alignments(
    nwb, 
    {'rewarded goCue':rewarded_go_cues,'unrewarded goCue':unrewarded_go_cues}, 
    channel, 
    censor=True
    )
```
But now we can analyze and combine multiple sessions
```
alignments = []
for nwb in nwb_list:
    rewarded_go_cues = nwb.df_trials.query('earned_reward == 1')['goCue_start_time_in_session'].values
    unrewarded_go_cues = nwb.df_trials.query('earned_reward == 0')['goCue_start_time_in_session'].values
    alignments.append( {'rewarded goCue':rewarded_go_cues,'unrewarded goCue':unrewarded_go_cues})
pf.plot_fip_psth_compare_alignments(
    nwb_list, 
    alignments, 
    channel, 
    censor=True,
    error_type='sem'
    )
```
We can also use columns names in df_events:
```
pf.plot_fip_psth_compare_alignments(
    nwb_list, 
    ['goCue_start_time'], 
    channel, 
    censor=True,
    error_type='sem'
    )
```

The `error_type` keyword lets the user select between: 
- `sem` the standard error of the mean over all samples
- `sem_over_sessions` the standard error of the mean over sessions. 