### PR TITLE
adding alpha so we can see a bit better if the metrics overlap

### DIFF
--- a/src/aind_dynamic_foraging_basic_analysis/plot/plot_session_scroller.py
+++ b/src/aind_dynamic_foraging_basic_analysis/plot/plot_session_scroller.py
@@ -487,7 +487,7 @@ def plot_metric(df_trials, go_cue_times, metric, ax):
     # plot metrics for this axis
     for m in metric_names:
         if m in df_trials:
-            ax.plot(go_cue_times, df_trials[m], label=m)
+            ax.plot(go_cue_times, df_trials[m], label=m, alpha=0.7)
         else:
             raise Exception("metric not in df_trials: {}".format(m))
 


### PR DESCRIPTION
sometimes metrics overlap (for example, Q_left = 0, Q_right = 1, Q_Delta = 1) 


giving metrics an alpha so we can see if that happens. 