### PR TITLE
Add 'aind_dynamic_foraging_models' to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ dependencies = [
     'pydantic',
     'hdmf_zarr',
     'aind-dynamic-foraging-data-utils >= 0.1.25',
-    'aind_hierarchical_bootstrap'
+    'aind_hierarchical_bootstrap',
+    'aind_dynamic_foraging_models'
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
trial_metrics requires aind_dynamic_foraging_model, so we should add this to the dependencies