### PR TITLE
Allow multiple FIP channels in plot axis of session scroller

### DIFF
--- a/src/aind_dynamic_foraging_basic_analysis/plot/plot_session_scroller.py
+++ b/src/aind_dynamic_foraging_basic_analysis/plot/plot_session_scroller.py
@@ -518,9 +518,9 @@ def plot_fip(fip_df, channel, ax):
             if sub_channel not in fip_df['event'].unique():
                 raise Exception("Cannot plot {}, no data".format(sub_channel))
 
-            color = get_fip_color(channel)
-            C = fip_df.query("event == @channel")
-            ax.plot(C.timestamps.values, C.data.values, color,label=channel)
+            color = get_fip_color(sub_channel)
+            C = fip_df.query("event == @sub_channel")
+            ax.plot(C.timestamps.values, C.data.values, color,label=sub_channel)
         ax.set_ylabel('multiple', fontsize=12)
         ax.legend()
     else:

--- a/src/aind_dynamic_foraging_basic_analysis/plot/plot_session_scroller.py
+++ b/src/aind_dynamic_foraging_basic_analysis/plot/plot_session_scroller.py
@@ -515,13 +515,13 @@ def plot_fip(fip_df, channel, ax):
 
     if isinstance(channel, list):
         for sub_channel in channel:
-            if sub_channel not in fip_df['event'].unique():
+            if sub_channel not in fip_df["event"].unique():
                 raise Exception("Cannot plot {}, no data".format(sub_channel))
 
             color = get_fip_color(sub_channel)
             C = fip_df.query("event == @sub_channel")
-            ax.plot(C.timestamps.values, C.data.values, color,label=sub_channel)
-        ax.set_ylabel('multiple', fontsize=12)
+            ax.plot(C.timestamps.values, C.data.values, color, label=sub_channel)
+        ax.set_ylabel("multiple", fontsize=12)
         ax.legend()
     else:
         if channel not in fip_df["event"].unique():
@@ -532,6 +532,7 @@ def plot_fip(fip_df, channel, ax):
         ax.plot(C.timestamps.values, C.data.values, color)
         ax.set_ylabel(channel, fontsize=12)
     ax.axhline(0, color="k", linewidth=0.5, alpha=0.25)
+
 
 def get_fip_color(channel):
     """

--- a/src/aind_dynamic_foraging_basic_analysis/plot/plot_session_scroller.py
+++ b/src/aind_dynamic_foraging_basic_analysis/plot/plot_session_scroller.py
@@ -513,15 +513,25 @@ def plot_fip(fip_df, channel, ax):
     if fip_df is None:
         raise Exception("Cannot plot FIP, no FIP data")
 
-    if channel not in fip_df["event"].unique():
-        raise Exception("Cannot plot {}, no data".format(channel))
+    if isinstance(channel, list):
+        for sub_channel in channel:
+            if sub_channel not in fip_df['event'].unique():
+                raise Exception("Cannot plot {}, no data".format(sub_channel))
 
-    color = get_fip_color(channel)
-    C = fip_df.query("event == @channel")
-    ax.plot(C.timestamps.values, C.data.values, color)
+            color = get_fip_color(channel)
+            C = fip_df.query("event == @channel")
+            ax.plot(C.timestamps.values, C.data.values, color,label=channel)
+        ax.set_ylabel('multiple', fontsize=12)
+        ax.legend()
+    else:
+        if channel not in fip_df["event"].unique():
+            raise Exception("Cannot plot {}, no data".format(channel))
+
+        color = get_fip_color(channel)
+        C = fip_df.query("event == @channel")
+        ax.plot(C.timestamps.values, C.data.values, color)
+        ax.set_ylabel(channel, fontsize=12)
     ax.axhline(0, color="k", linewidth=0.5, alpha=0.25)
-    ax.set_ylabel(channel, fontsize=12)
-
 
 def get_fip_color(channel):
     """


### PR DESCRIPTION
Allows plotting multiple FIP channels in the same axis on the session scroller:

```
fip = [
    ["G_0","Iso_0"],
    ["G_0_dff-bright","Iso_0_dff-bright"],
    ["G_0_dff-bright_mc-iso-IRLS","Iso_0_dff-bright_mc-iso-IRLS"],

]
plot_session_scroller(nwb,fip=fip)
```